### PR TITLE
Add python 3.9 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 __pycache__
 *.pyc
 poetry.lock
+.python-version

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__
 *.pyc
 poetry.lock
 .python-version
+.pytest_cache
+.vscode

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install reagentpy-<version>-py3-none-any.whl
 You can install the dev build with [`poetry`](https://python-poetry.org/) by navigating to the root of this repo and running the following:
 
 ```
-poetry install
+poetry install --with dev
 ```
 
 **Testing**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,11 @@ python = "^3.9"
 requests = "^2.32.3"
 pandas = "^2.2.3"
 click = "^8.1.7"
+python-dotenv = "^1.0.1"
 
 [tool.poetry.group.dev.dependencies]
 ipykernel = "^6.29.5"
 pytest = "^6.2.5"
-python-dotenv = "^1.0.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,20 +11,17 @@ license = "LICENSE"
 [tool.poetry.dependencies]
 python = "^3.9"
 requests = "^2.32.3"
-python-dotenv = "^1.0.1"
 pandas = "^2.2.3"
 click = "^8.1.7"
 
-[tool.poetry.dev-dependencies]
-pytest = "^6.2.5"
-
 [tool.poetry.group.dev.dependencies]
 ipykernel = "^6.29.5"
+pytest = "^6.2.5"
+python-dotenv = "^1.0.1"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
 
 [tool.poetry.scripts]
 reagent = "reagentpy.cli:cli"

--- a/reagentpy/clients/community.py
+++ b/reagentpy/clients/community.py
@@ -1,12 +1,13 @@
 from reagentpy.clients import ReagentClient, ReagentResponse
+from typing import Optional
 
 class CommunityClient(ReagentClient):
     def __init__(self):
         super().__init__()
 
-    def maintainers(self, repo: str | None = None, limit: int = 10, email: str | None = None,
-                      name: str | None = None, timezone: float | None = None, file: str | None = None, 
-                      hibp: bool | None = None, community: str | None = None):
+    def maintainers(self, repo: Optional[str] = None, limit: int = 10, email: Optional[str] = None,
+                    name: Optional[str] = None, timezone: Optional[float] = None, file: Optional[str] = None, 
+                    hibp: Optional[bool] = None, community: Optional[str] = None):
         """Given a repo or user information, get all the maintainers of mutual file communities."""
 
         query_params = {
@@ -22,8 +23,8 @@ class CommunityClient(ReagentClient):
 
         return ReagentResponse(self.session.get(f"{self.reagent_base_url}/community/maintainers", params=query_params))
 
-    def communities(self, repo: str | None = None, limit: int = 10, timezone: float | None = None,
-                      start_date: str | None = None, end_date: str | None = None):
+    def communities(self, repo: Optional[str] = None, limit: int = 10, timezone: Optional[float] = None,
+                      start_date: Optional[str] = None, end_date: Optional[str] = None):
         """Get all file communities (usually features) in a repo, given repo information."""
 
         query_params = {

--- a/reagentpy/clients/enrichments.py
+++ b/reagentpy/clients/enrichments.py
@@ -1,11 +1,12 @@
 from reagentpy.clients import ReagentClient, ReagentResponse
+from typing import Optional
 
 class EnrichmentsClient(ReagentClient):
     def __init__(self):
         super().__init__()
 
-    def foreign_influence(self, entity_name: str | None = None, limit: int = 10, entity_type: str | None = None,
-                      no_unspecified: bool | None = None, start_date: str | None = None, end_date: str | None = None):
+    def foreign_influence(self, entity_name: Optional[str] = None, limit: int = 10, entity_type: Optional[str] = None,
+                      no_unspecified: Optional[bool] = None, start_date: Optional[str] = None, end_date: Optional[str] = None):
         """Given a repo name, get a snapshot of foreign influence on all commits in the repo."""
 
         query_params = {
@@ -19,8 +20,8 @@ class EnrichmentsClient(ReagentClient):
 
         return ReagentResponse(self.session.get(f"{self.reagent_base_url}/enrichments/foreign_influence", params=query_params))
 
-    def hibp(self, repo: str | None = None, limit: int = 10, breach: str | None = None,
-                email: str | None = None, timezone: str | None = None):
+    def hibp(self, repo: Optional[str] = None, limit: int = 10, breach: Optional[str] = None,
+                email: Optional[str] = None, timezone: Optional[str] = None):
         """Given a repo name or email address, get all data breaches the entity is a part of."""
 
         query_params = {
@@ -33,8 +34,8 @@ class EnrichmentsClient(ReagentClient):
 
         return ReagentResponse(self.session.get(f"{self.reagent_base_url}/enrichments/hibp", params=query_params))
 
-    def similar_repos(self, repo: str | None = None, limit: int = 10, email: str | None = None, 
-                        timezone: str | None = None, start_date: str | None = None, end_date: str | None = None):
+    def similar_repos(self, repo: Optional[str] = None, limit: int = 10, email: Optional[str] = None, 
+                        timezone: Optional[str] = None, start_date: Optional[str] = None, end_date: Optional[str] = None):
         """Given a repository, get similar organizations and tags common between them."""
 
         query_params = {
@@ -48,7 +49,7 @@ class EnrichmentsClient(ReagentClient):
 
         return ReagentResponse(self.session.get(f"{self.reagent_base_url}/enrichments/similar_repos", params=query_params))
     
-    def timezone_spoof(self, repo: str | None = None, limit: int = 10):
+    def timezone_spoof(self, repo: Optional[str] = None, limit: int = 10):
         """Given a repo name, get all fabricated timezone information."""
 
         query_params = {
@@ -58,8 +59,8 @@ class EnrichmentsClient(ReagentClient):
 
         return ReagentResponse(self.session.get(f"{self.reagent_base_url}/enrichments/timezone_spoof", params=query_params))
     
-    def topics(self, repo: str | None = None, limit: int = 10, email: str | None = None,
-                        timezone: str | None = None, name: str | None = None):
+    def topics(self, repo: Optional[str] = None, limit: int = 10, email: Optional[str] = None,
+                        timezone: Optional[str] = None, name: Optional[str] = None):
         """Get topics (categories of code based on commit messages and repository READMEs) by repository or user."""
 
         query_params = {
@@ -72,7 +73,7 @@ class EnrichmentsClient(ReagentClient):
 
         return ReagentResponse(self.session.get(f"{self.reagent_base_url}/enrichments/topics", params=query_params))
     
-    def threat_summary(self, repo: str | None = None, adversarial: bool | None = None, limit: int = 10):
+    def threat_summary(self, repo: Optional[str] = None, adversarial: Optional[bool] = None, limit: int = 10):
         """Given a kind of threat and repo name, get threat score info (project fragmentation, unfocused contribution, context switching, interactive churn)."""
         query_params = {
             "repo_name": repo,
@@ -82,7 +83,7 @@ class EnrichmentsClient(ReagentClient):
 
         return ReagentResponse(self.session.get(f"{self.reagent_base_url}/enrichments/threat/summary", params=query_params))
     
-    def threat_score(self, repo: str | None = None):
+    def threat_score(self, repo: Optional[str] = None):
         """Given a kind of threat and repo name, get threat score info (project fragmentation, unfocused contribution, context switching, interactive churn)."""
         query_params = {
             "repo": repo

--- a/reagentpy/clients/repo.py
+++ b/reagentpy/clients/repo.py
@@ -1,11 +1,12 @@
 from reagentpy.clients import ReagentClient, ReagentResponse
+from typing import Optional
 
 class RepoClient(ReagentClient):
     def __init__(self):
         super().__init__()
 
-    def email_domains(self, repo: str | None = None, limit: int = 10, 
-                      timezone: float | None = None, start_date: str | None = None, end_date: str | None = None):
+    def email_domains(self, repo: Optional[str] = None, limit: int = 10, 
+                      timezone: Optional[float] = None, start_date: Optional[str] = None, end_date: Optional[str] = None):
         """Given a repository, get all the other organizations that contributing users are working in."""
 
         query_params = {
@@ -18,8 +19,8 @@ class RepoClient(ReagentClient):
 
         return ReagentResponse(self.session.get(f"{self.reagent_base_url}/repo/email_domains", params=query_params))
 
-    def timezones(self, repo: str | None = None, email: str | None = None,
-                      timezone: float | None = None, name: str | None = None):
+    def timezones(self, repo: Optional[str] = None, email: Optional[str] = None,
+                      timezone: Optional[float] = None, name: Optional[str] = None):
         """Given a repo name, get number of commits and timezone data."""
 
         query_params = {
@@ -32,9 +33,9 @@ class RepoClient(ReagentClient):
         return ReagentResponse(self.session.get(f"{self.reagent_base_url}/repo/timezones", params=query_params))
     
 
-    def user_commit_data(self, repo: str | None = None, limit: int = 10, email: str | None = None, name: str | None = None,
-                      timezone: float | None = None, start_date: str | None = None, end_date: str | None = None,
-                      order_by_date: bool | None = None, include_other_repos: bool | None = None, format_in_rows: bool | None = None):
+    def user_commit_data(self, repo: Optional[str] = None, limit: int = 10, email: Optional[str] = None, name: Optional[str] = None,
+                      timezone: Optional[float] = None, start_date: Optional[str] = None, end_date: Optional[str] = None,
+                      order_by_date: Optional[bool] = None, include_other_repos: Optional[bool] = None, format_in_rows: Optional[bool] = None):
         """Given a repo name and timezone, get users above a certain threshold for finer-grained intelligence."""
 
         query_params = {

--- a/reagentpy/clients/user.py
+++ b/reagentpy/clients/user.py
@@ -1,12 +1,13 @@
 from reagentpy.clients import ReagentClient, ReagentResponse
+from typing import Optional
 
 class UserClient(ReagentClient):
     def __init__(self):
         super().__init__()
 
-    def commit_file_community(self, repo: str | None = None, limit: int = 10, email: str | None = None, name: str | None = None,
-                      order_by_date: bool | None = None, format_in_rows: bool | None = None,
-                      timezone: float | None = None, start_date: str | None = None, end_date: str | None = None):
+    def commit_file_community(self, repo: Optional[str] = None, limit: int = 10, email: Optional[str] = None, name: Optional[str] = None,
+                      order_by_date: Optional[bool] = None, format_in_rows: Optional[bool] = None,
+                      timezone: Optional[float] = None, start_date: Optional[str] = None, end_date: Optional[str] = None):
         """Get threat scores, repos, and top developers on files."""
 
         query_params = {
@@ -23,8 +24,8 @@ class UserClient(ReagentClient):
 
         return ReagentResponse(self.session.get(f"{self.reagent_base_url}/user/commit_file_community", params=query_params))
 
-    def post_patch(self, repo: str | None = None, limit: int = 10, email: str | None = None,
-                      timezone: float | None = None, start_date: str | None = None, end_date: str | None = None):
+    def post_patch(self, repo: Optional[str] = None, limit: int = 10, email: Optional[str] = None,
+                      timezone: Optional[float] = None, start_date: Optional[str] = None, end_date: Optional[str] = None):
         """Get everything a user has done, sorting by most recent suspicious activity and whether their potentially introduced security vulnerabilities have been patched."""
 
         query_params = {
@@ -39,8 +40,8 @@ class UserClient(ReagentClient):
         return ReagentResponse(self.session.get(f"{self.reagent_base_url}/user/post_patch", params=query_params))
 
 
-    def profile(self, limit: int = 10, email: str | None = None, name: str | None = None,
-                      timezone: float | None = None, start_date: str | None = None, end_date: str | None = None):
+    def profile(self, limit: int = 10, email: Optional[str] = None, name: Optional[str] = None,
+                      timezone: Optional[float] = None, start_date: Optional[str] = None, end_date: Optional[str] = None):
         """Get contributor profiles for a given user."""
 
         query_params = {


### PR DESCRIPTION
The shorthand notation `str | None` was introduced in Python 3.10 and isn't compatible with 3.9 - I have a requirement to use this package in a Python 3.9 environment. I made some slight modifications to the pyproject.toml to better isolate dev dependencies. This could be useful down the road when running ci/cd and it is the canonical approach. Added a couple entries into .gitignore to better support vscode users and pyenv users.